### PR TITLE
Julio/activity lifecycle

### DIFF
--- a/app/src/main/java/com/GrowthPlus/CreateAccount.java
+++ b/app/src/main/java/com/GrowthPlus/CreateAccount.java
@@ -46,36 +46,33 @@ public class CreateAccount extends AppCompatActivity {
         ChildRoadMap childRoadMapFour = new ChildRoadMap("roadMapFour", 0, false, false, false, null, null, null);
 
         // Go to main page with update new child
-        View.OnClickListener goNext = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (!nameInput.getText().toString().equals(null) && !nameInput.getText().toString().equals("")){
+        View.OnClickListener goNext = v -> {
+            if (!nameInput.getText().toString().equals(null) && !nameInput.getText().toString().equals("")){
 
-                    newChild = new ChildSchemaService(realm,
-                            nameInput.getText().toString(),
-                            animalName,
-                            colorName, 0,
-                            childRoadMapOne,
-                            childRoadMapTwo,
-                            childRoadMapThree,
-                            childRoadMapFour);
+                newChild = new ChildSchemaService(realm,
+                        nameInput.getText().toString(),
+                        animalName,
+                        colorName, 0,
+                        childRoadMapOne,
+                        childRoadMapTwo,
+                        childRoadMapThree,
+                        childRoadMapFour);
 
-                    ObjectId childId = new ObjectId();
-                    newChild.createChildSchema(String.valueOf(childId)); // Create new child in realm database
-                    startActivity(new Intent(CreateAccount.this, MainActivity.class));
-                    finish();
-                }
+                ObjectId childId = new ObjectId();
+                newChild.createChildSchema(String.valueOf(childId)); // Create new child in realm database
+                Intent intent = new Intent(CreateAccount.this, MainActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                finish();
+                overridePendingTransition(0, 0);
+                startActivity(intent);
+                overridePendingTransition(0, 0);
             }
         };
         loginButton.setOnClickListener(goNext);
 
         // Go back to select child avatar
-        View.OnClickListener goBack = new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(CreateAccount.this, SelectChildAvatar.class));
-                finish();
-            }
+        View.OnClickListener goBack = v -> {
+            finish();
         };
         backButton.setOnClickListener(goBack);
     }

--- a/app/src/main/java/com/GrowthPlus/MainActivity.java
+++ b/app/src/main/java/com/GrowthPlus/MainActivity.java
@@ -12,11 +12,10 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
-import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.TextView;
-import android.widget.Toast;
+
 
 import com.GrowthPlus.customViews.LandingPageAddChild;
 import com.GrowthPlus.customViews.LandingPageChildCard;
@@ -35,11 +34,11 @@ import io.realm.RealmObject;
 import io.realm.RealmResults;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener{
-    ColorIdentifier colorIdentifier;
-    ColorStateList red, darkGreen, blue, yellow, lightGreen;
-    Realm realm;
-    Resources resources;
-    private FrameLayout childPortal;
+    private ColorIdentifier colorIdentifier;
+    private ColorStateList red, darkGreen, blue, yellow, lightGreen;
+    private Realm realm;
+    private Resources resources;
+    private FrameLayout parentPortal;
     private ImageButton language;
     private TextView parentText;
     private GridLayout landingPageGridLayout;
@@ -49,7 +48,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     public ImageSrcIdentifier imageSrcIdentifier;
     public final int MAX_CHILDREN = 6;
     public AlphaAnimation buttonClick = new AlphaAnimation(1F, 0.8F);
-    JsonSampleData jsonSampleData;
+    private JsonSampleData jsonSampleData;
+    private RealmResults<ChildSchema> children;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,70 +58,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         init();
         importRoadMapData();
 
-        RealmResults<ChildSchema> children = landingPageChildren.getAllChildSchemas();
+        setAllLandingPageCards(children);
 
-        LandingPageChildCard childCardTemp;
-        ChildSchema childTemp;
-
-        int childrenNum = children.size();
-        Log.i("Num of children", String.valueOf(childrenNum));
-        int random;
-        String childIdTemp;
-        String childNameTemp;
-        String avatarNameTemp;
-        String colorNameTemp;
-
-        for(int index = 0; index < childrenNum; index ++){
-            childTemp = children.get(index);
-
-            childIdTemp = childTemp.getChildId();
-            childNameTemp = childTemp.getName();
-            avatarNameTemp = childTemp.getAvatarName();
-            colorNameTemp = childTemp.getColorName();
-
-            childCardTemp = setLandingPageChildCard(landingPageChildCardIds.get(index), childNameTemp, avatarNameTemp, colorNameTemp);
-            landingPageGridLayout.addView(childCardTemp, index);
-
-            landingPageChildId.put(landingPageChildCardIds.get(index), childIdTemp);
-
-            childCardTemp = null;
-            childTemp = null;
-        }
-
-        if(childrenNum < MAX_CHILDREN){
-            LandingPageAddChild landingPageAddChild = new LandingPageAddChild(this);
-            landingPageAddChild.setId(R.id.landingPageChildCardAdd);
-            landingPageAddChild.setOnClickListener(this);
-
-            // Produces a 'random' color for the add student button
-            Random rand = new Random();
-            random = rand.nextInt(5);
-            if(random == 0){
-                landingPageAddChild.setCircleColor(red);
-                landingPageAddChild.setAddIconColor(blue);
-            }
-            else if(random == 1){
-                landingPageAddChild.setCircleColor(darkGreen);
-                landingPageAddChild.setAddIconColor(yellow);
-            }
-            else if(random == 2){
-                landingPageAddChild.setCircleColor(darkGreen);
-                landingPageAddChild.setAddIconColor(blue);
-            }
-            else if(random == 3){
-                landingPageAddChild.setCircleColor(lightGreen);
-                landingPageAddChild.setAddIconColor(darkGreen);
-            }
-            else{
-                landingPageAddChild.setCircleColor(yellow);
-                landingPageAddChild.setAddIconColor(red);
-            }
-
-            landingPageGridLayout.addView(landingPageAddChild);
-        }
-
-        // TODO: this button is currently navigating to child portal, change to parent portal
-        childPortal.setOnClickListener(this);
+        parentPortal.setOnClickListener(this);
         language.setOnClickListener(this);
     }
 
@@ -129,7 +68,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         realm = Realm.getDefaultInstance();
         resources = getResources();
         jsonSampleData = new JsonSampleData(realm, resources);
-        childPortal = findViewById(R.id.idParent);
+        parentPortal = findViewById(R.id.idParent);
         language = findViewById(R.id.langBtn);
         landingPageGridLayout = findViewById(R.id.landingPageChildGrid);
         parentText = findViewById(R.id.parentText);
@@ -146,12 +85,12 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         landingPageChildCardIds = new HashMap<>();
         setLandingPageChildCardIds();
+        children = landingPageChildren.getAllChildSchemas();
 
         Bundle extras = getIntent().getExtras();
         if (extras != null) {
             parentText.setText(extras.getString("setParent"));
         }
-
     }
 
     private void importSampleData(){
@@ -252,6 +191,70 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     public void startAddChildActivity(){
         Intent selectChildAvatar = new Intent(MainActivity.this, SelectChildAvatar.class);
+        selectChildAvatar.putExtra("comingFrom", "LandingPage");
         startActivity(selectChildAvatar);
+    }
+
+    private void setAllLandingPageCards(RealmResults<ChildSchema> children){
+        LandingPageChildCard childCardTemp;
+        ChildSchema childTemp;
+
+        int childrenNum = children.size();
+        Log.i("Num of children", String.valueOf(childrenNum));
+        int random;
+        String childIdTemp;
+        String childNameTemp;
+        String avatarNameTemp;
+        String colorNameTemp;
+
+        for(int index = 0; index < childrenNum; index ++){
+            childTemp = children.get(index);
+
+            childIdTemp = childTemp.getChildId();
+            childNameTemp = childTemp.getName();
+            avatarNameTemp = childTemp.getAvatarName();
+            colorNameTemp = childTemp.getColorName();
+
+            childCardTemp = setLandingPageChildCard(landingPageChildCardIds.get(index), childNameTemp, avatarNameTemp, colorNameTemp);
+            landingPageGridLayout.addView(childCardTemp, index);
+
+            landingPageChildId.put(landingPageChildCardIds.get(index), childIdTemp);
+
+            childCardTemp = null;
+            childTemp = null;
+        }
+
+        if(childrenNum < MAX_CHILDREN){
+            LandingPageAddChild landingPageAddChild = new LandingPageAddChild(this);
+            landingPageAddChild.setId(R.id.landingPageChildCardAdd);
+            landingPageAddChild.setOnClickListener(this);
+
+            // Produces a 'random' color for the add student button
+            Random rand = new Random();
+            random = rand.nextInt(5);
+            if(random == 0){
+                landingPageAddChild.setCircleColor(red);
+                landingPageAddChild.setAddIconColor(blue);
+            }
+            else if(random == 1){
+                landingPageAddChild.setCircleColor(darkGreen);
+                landingPageAddChild.setAddIconColor(yellow);
+            }
+            else if(random == 2){
+                landingPageAddChild.setCircleColor(darkGreen);
+                landingPageAddChild.setAddIconColor(blue);
+            }
+            else if(random == 3){
+                landingPageAddChild.setCircleColor(lightGreen);
+                landingPageAddChild.setAddIconColor(darkGreen);
+            }
+            else{
+                landingPageAddChild.setCircleColor(yellow);
+                landingPageAddChild.setAddIconColor(red);
+            }
+
+            landingPageGridLayout.addView(landingPageAddChild);
+        }
+
     }
 }

--- a/app/src/main/java/com/GrowthPlus/ParentPortal.java
+++ b/app/src/main/java/com/GrowthPlus/ParentPortal.java
@@ -216,14 +216,8 @@ public class ParentPortal extends AppCompatActivity implements View.OnClickListe
 
         if((view.getId()) == R.id.backChild) {
             startLandingPageActivity();
-            this.finish();
         }
 
-    }
-
-    @Override
-    public void onPointerCaptureChanged(boolean hasCapture) {
-        super.onPointerCaptureChanged(hasCapture);
     }
 
     public void startChildScreenActivity(String childId){
@@ -235,6 +229,7 @@ public class ParentPortal extends AppCompatActivity implements View.OnClickListe
 
     public void startSelectChildAvatarActivity(){
         Intent selectChildAvatar = new Intent(ParentPortal.this, SelectChildAvatar.class);
+        selectChildAvatar.putExtra("comingFrom", "ParentPortal");
         startActivity(selectChildAvatar);
     }
 

--- a/app/src/main/java/com/GrowthPlus/SelectChildAvatar.java
+++ b/app/src/main/java/com/GrowthPlus/SelectChildAvatar.java
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.widget.Button;
@@ -12,6 +13,7 @@ import android.widget.ImageView;
 public class SelectChildAvatar extends AppCompatActivity implements View.OnClickListener{
     private ImageView bunny, elephant, bird, camel, giraffe, squirrel;
     private Button backSelect;
+    private String goBackTo;
     private AlphaAnimation buttonClick = new AlphaAnimation(1F, 0.8F);
 
     @Override
@@ -19,6 +21,8 @@ public class SelectChildAvatar extends AppCompatActivity implements View.OnClick
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_select_child_avatar);
         init();
+
+        Log.i("goBackTo", goBackTo);
 
         ImageView topLeft = (ImageView) findViewById(R.id.bunnyOption);
         topLeft.setOnClickListener(this);
@@ -49,6 +53,10 @@ public class SelectChildAvatar extends AppCompatActivity implements View.OnClick
         giraffe = findViewById(R.id.giraffeOption);
         squirrel = findViewById(R.id.squirrelOption);
         backSelect = findViewById(R.id.backSelectChild);
+        Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            goBackTo = extras.getString("comingFrom");
+        }
     }
 
     @Override

--- a/app/src/main/java/com/GrowthPlus/childScreen.java
+++ b/app/src/main/java/com/GrowthPlus/childScreen.java
@@ -91,6 +91,8 @@ public class childScreen extends AppCompatActivity {
                 deleteChild.deleteFromRealm();
 
             });
+            Intent intent = new Intent(childScreen.this, ParentPortal.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(new Intent(childScreen.this, ParentPortal.class));
             this.finish();
         });


### PR DESCRIPTION
This PR implements a refresh for the landing page when creating or deleting a child. 

To test:
Have some space for the creation of two children, might need to delete some before. 
Create a child from the landing page. 
Create a child from the parent portal. 
In both instances, the app should redirect you to the landing page with the updated number of children. 
Play around with the back buttons and make sure the navigation makes sense. 

Note: 
You might notice a white flicker after creating a new child and right before landing in the landing page, this is expected, we are refreshing the whole UI by re-creating the activity and triggering an update, after the creation of the new child, the stack that keeps track of the activities gets clean up and anything on top of landing page will be clear out, this is so we don't have any trailing activities with old data. 
This flicker can be mitigated by implementing a loading spinner after creating a new child and before the activity is created, this could be a future ticket.  