### PR TITLE
Ruth/populate json lessons

### DIFF
--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/Lesson/LessonSchema.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/Lesson/LessonSchema.java
@@ -1,5 +1,7 @@
 package com.GrowthPlus.dataAccessLayer.Lesson;
 
+import com.GrowthPlus.dataAccessLayer.LessonContent.LessonContent;
+
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
@@ -12,6 +14,7 @@ public class LessonSchema extends RealmObject{
     private String lessonName;
     private String category;
     private String image;
+    private RealmList<LessonContent> contents;
 
     public String getLessonId() {
         return lessonId;
@@ -59,5 +62,13 @@ public class LessonSchema extends RealmObject{
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public RealmList<LessonContent> getContents() {
+        return contents;
+    }
+
+    public void setContents(RealmList<LessonContent> contents){
+        this.contents = contents;
     }
 }

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/Lesson/LessonSchemaService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/Lesson/LessonSchemaService.java
@@ -2,7 +2,10 @@ package com.GrowthPlus.dataAccessLayer.Lesson;
 
 import android.util.Log;
 
+import com.GrowthPlus.dataAccessLayer.LessonContent.LessonContent;
+
 import io.realm.Realm;
+import io.realm.RealmList;
 import io.realm.RealmResults;
 
 public class LessonSchemaService {
@@ -12,14 +15,16 @@ public class LessonSchemaService {
     private Integer minPoints;
     private String lessonName;
     private String image;
+    private RealmList<LessonContent> contents;
 
-    public LessonSchemaService(Realm realm, String lessonId, Integer maxPoints, Integer minPoints, String lessonName, String image) {
+    public LessonSchemaService(Realm realm, String lessonId, Integer maxPoints, Integer minPoints, String lessonName, String image, RealmList<LessonContent> contents) {
         this.realm = realm;
         this.lessonId = lessonId;
         this.maxPoints = maxPoints;
         this.minPoints = minPoints;
         this.lessonName = lessonName;
         this.image = image;
+        this.contents = contents;
     }
 
     public String getLessonId() {
@@ -34,6 +39,7 @@ public class LessonSchemaService {
                 newLessonSchema.setMinPoints(minPoints);
                 newLessonSchema.setMaxPoints(maxPoints);
                 newLessonSchema.setImage(image);
+                newLessonSchema.setContents(contents);
             }, () ->{
                 Log.i("Success", "New Lesson added to realm");
             }, error -> {

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContent.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContent.java
@@ -1,0 +1,30 @@
+package com.GrowthPlus.dataAccessLayer.LessonContent;
+
+import java.util.ArrayList;
+
+import io.realm.RealmObject;
+import io.realm.annotations.PrimaryKey;
+
+public class LessonContent extends RealmObject {
+    @PrimaryKey
+    private String lessonContentId;
+    private String word;
+    private String number;
+    private String imgNum;
+
+    public String getLessonContentId() { return lessonContentId; }
+
+    public void setLessonContentId(String lessonContentId) { this.lessonContentId = lessonContentId; }
+
+    public String getWord() { return word; }
+
+    public void setWord(String word) { this.word = word; }
+
+    public String getNumber() { return number; }
+
+    public void setNumber(String numbers) { this.number = number; }
+
+    public String getImgNum() { return imgNum; }
+
+    public void setImgNum(String imgNum) { this.imgNum = imgNum; }
+}

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContent.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContent.java
@@ -9,8 +9,16 @@ public class LessonContent extends RealmObject {
     @PrimaryKey
     private String lessonContentId;
     private String word;
-    private String number;
-    private String imgNum;
+    private String firstNumber;
+    private String firstOperator;
+    private String secondNumber;
+    private String secondOperator;
+    private String thirdNumber;
+    private String imgOne;
+    private String imgTwo;
+    private String imgThree;
+    private String imgFour;
+    private String imgFive;
 
     public String getLessonContentId() { return lessonContentId; }
 
@@ -20,11 +28,44 @@ public class LessonContent extends RealmObject {
 
     public void setWord(String word) { this.word = word; }
 
-    public String getNumber() { return number; }
+    public String getFirstNumber() { return firstNumber; }
 
-    public void setNumber(String numbers) { this.number = number; }
+    public void setFirstNumber(String firstNumber) { this.firstNumber = firstNumber; }
 
-    public String getImgNum() { return imgNum; }
+    public String getFirstOperator() { return firstOperator; }
 
-    public void setImgNum(String imgNum) { this.imgNum = imgNum; }
+    public void setFirstOperator(String firstOperator) { this.firstOperator = firstOperator; }
+
+    public String getSecondNumber() { return secondNumber; }
+
+    public void setSecondNumber(String secondNumber) { this.secondNumber = secondNumber; }
+
+    public String getSecondOperator() { return secondOperator; }
+
+    public void setSecondOperator(String secondOperator) { this.secondOperator = secondOperator; }
+
+    public String getThirdNumber() { return thirdNumber; }
+
+    public void setThirdNumber(String thirdNumber) { this.thirdNumber = thirdNumber; }
+
+    public String getImgOne() { return imgOne; }
+
+    public void setImgOne(String imgOne) { this.imgOne = imgOne; }
+
+    public String getImgTwo() { return imgTwo; }
+
+    public void setImgTwo(String imgTwo) { this.imgTwo = imgTwo; }
+
+    public String getImgThree() { return imgThree; }
+
+    public void setImgThree(String imgThree) { this.imgThree = imgThree; }
+
+    public String getImgFour() { return imgFour; }
+
+    public void setImgFour(String imgFour) { this.imgFour = imgFour; }
+
+    public String getImgFive() { return imgFive; }
+
+    public void setImgFive(String imgFive) { this.imgFive = imgFive; }
+
 }

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
@@ -11,16 +11,32 @@ public class LessonContentService {
     private Realm realm;
     private String lessonContentId;
     private String word;
-    private String number;
-    private String imgNum;
+    private String firstNumber;
+    private String firstOperator;
+    private String secondNumber;
+    private String secondOperator;
+    private String thirdNumber;
+    private String imgOne;
+    private String imgTwo;
+    private String imgThree;
+    private String imgFour;
+    private String imgFive;
 
 
-    public LessonContentService(Realm realm, String lessonContentId, String word, String number, String imgNum) {
+    public LessonContentService(Realm realm, String lessonContentId, String word, String firstNumber, String firstOperator, String secondNumber, String secondOperator, String thirdNumber, String imgOne, String imgTwo, String imgThree, String imgFour, String imgFive) {
         this.realm = realm;
         this.lessonContentId = lessonContentId;
         this.word = word;
-        this.number = number;
-        this.imgNum = imgNum;
+        this.firstNumber = firstNumber;
+        this.firstOperator = firstOperator;
+        this.secondNumber = secondNumber;
+        this.secondOperator = secondOperator;
+        this.thirdNumber = thirdNumber;
+        this.imgOne = imgOne;
+        this.imgTwo = imgTwo;
+        this.imgThree = imgThree;
+        this.imgFour = imgFour;
+        this.imgFive = imgFive;
     }
 
     public String getLessonContentId() {
@@ -32,8 +48,16 @@ public class LessonContentService {
         realm.executeTransactionAsync(realm ->{
             LessonContent newLessonContent = realm.createObject(LessonContent.class, String.valueOf(lessonContentId));
             newLessonContent.setWord(word);
-            newLessonContent.setNumber(number);
-            newLessonContent.setImgNum(imgNum);
+            newLessonContent.setFirstNumber(firstNumber);
+            newLessonContent.setFirstOperator(firstOperator);
+            newLessonContent.setSecondNumber(secondNumber);
+            newLessonContent.setSecondOperator(secondOperator);
+            newLessonContent.setThirdNumber(thirdNumber);
+            newLessonContent.setImgOne(imgOne);
+            newLessonContent.setImgTwo(imgTwo);
+            newLessonContent.setImgThree(imgThree);
+            newLessonContent.setImgFour(imgFour);
+            newLessonContent.setImgFive(imgFive);
         }, () ->{
             Log.i("Success", "New Lesson Content added to realm");
         }, error -> {
@@ -45,21 +69,15 @@ public class LessonContentService {
         return realm.where(LessonContent.class).findAll();
     }
 
-    public LessonContent getLessonByName(){
+    public LessonContent getLessonById(){
         return realm.where(LessonContent.class)
-                .equalTo("word", word)
-                .findFirst();
-    }
-
-    public LessonContent getLessonById( String lessonId){
-        return realm.where(LessonContent.class)
-                .equalTo("lessonContentId", lessonId)
+                .equalTo("lessonContentId", lessonContentId)
                 .findFirst();
     }
 
     public void deleteRealmLessonContent(){
         realm.executeTransactionAsync(realm ->{
-            LessonContent lessonContent = getLessonByName();
+            LessonContent lessonContent = getLessonById();
             lessonContent.deleteFromRealm();
             lessonContent = null;
         });

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
@@ -75,11 +75,11 @@ public class LessonContentService {
                 .findFirst();
     }
 
-//    public void deleteRealmLessonContent(){
-//        realm.executeTransactionAsync(realm ->{
-//            LessonContent lessonContent = getLessonById(lessonContentId);
-//            lessonContent.deleteFromRealm();
-//            lessonContent = null;
-//        });
-//    }
+    public void deleteRealmLessonContent(){
+        realm.executeTransactionAsync(realm ->{
+            LessonContent lessonContent = getLessonById(lessonContentId);
+            lessonContent.deleteFromRealm();
+            lessonContent = null;
+        });
+    }
 }

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
@@ -69,17 +69,17 @@ public class LessonContentService {
         return realm.where(LessonContent.class).findAll();
     }
 
-    public LessonContent getLessonById(){
+    public LessonContent getLessonById(String lessonContentId){
         return realm.where(LessonContent.class)
                 .equalTo("lessonContentId", lessonContentId)
                 .findFirst();
     }
 
-    public void deleteRealmLessonContent(){
-        realm.executeTransactionAsync(realm ->{
-            LessonContent lessonContent = getLessonById();
-            lessonContent.deleteFromRealm();
-            lessonContent = null;
-        });
-    }
+//    public void deleteRealmLessonContent(){
+//        realm.executeTransactionAsync(realm ->{
+//            LessonContent lessonContent = getLessonById(lessonContentId);
+//            lessonContent.deleteFromRealm();
+//            lessonContent = null;
+//        });
+//    }
 }

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/LessonContent/LessonContentService.java
@@ -1,0 +1,67 @@
+package com.GrowthPlus.dataAccessLayer.LessonContent;
+
+import android.util.Log;
+
+import com.GrowthPlus.dataAccessLayer.Lesson.LessonSchema;
+
+import io.realm.Realm;
+import io.realm.RealmResults;
+
+public class LessonContentService {
+    private Realm realm;
+    private String lessonContentId;
+    private String word;
+    private String number;
+    private String imgNum;
+
+
+    public LessonContentService(Realm realm, String lessonContentId, String word, String number, String imgNum) {
+        this.realm = realm;
+        this.lessonContentId = lessonContentId;
+        this.word = word;
+        this.number = number;
+        this.imgNum = imgNum;
+    }
+
+    public String getLessonContentId() {
+        return lessonContentId;
+    }
+
+    public void createLessonContent (String lessonContentId){
+        this.lessonContentId = lessonContentId;
+        realm.executeTransactionAsync(realm ->{
+            LessonContent newLessonContent = realm.createObject(LessonContent.class, String.valueOf(lessonContentId));
+            newLessonContent.setWord(word);
+            newLessonContent.setNumber(number);
+            newLessonContent.setImgNum(imgNum);
+        }, () ->{
+            Log.i("Success", "New Lesson Content added to realm");
+        }, error -> {
+            Log.e("Error", "Something went wrong! " + error);
+        });
+    }
+
+    public RealmResults<LessonContent> getAllLessonContent(){
+        return realm.where(LessonContent.class).findAll();
+    }
+
+    public LessonContent getLessonByName(){
+        return realm.where(LessonContent.class)
+                .equalTo("word", word)
+                .findFirst();
+    }
+
+    public LessonContent getLessonById( String lessonId){
+        return realm.where(LessonContent.class)
+                .equalTo("lessonContentId", lessonId)
+                .findFirst();
+    }
+
+    public void deleteRealmLessonContent(){
+        realm.executeTransactionAsync(realm ->{
+            LessonContent lessonContent = getLessonByName();
+            lessonContent.deleteFromRealm();
+            lessonContent = null;
+        });
+    }
+}

--- a/app/src/main/res/raw/roadmap.json
+++ b/app/src/main/res/raw/roadmap.json
@@ -14,8 +14,16 @@
           {
             "lessonContentId": "lessonOneContentOne",
             "word": "one",
-            "number": "1",
-            "imgNum": "1"
+            "firstNumber": "",
+            "firstOperator": "",
+            "secondNumber": "",
+            "secondOperator": "",
+            "thirdNumber": "",
+            "imgOne": "",
+            "imgTwo": "",
+            "imgThree": "",
+            "imgFour": "",
+            "imgFive": ""
           },
           {
             "lessonContentId": "lessonOneContentTwo",

--- a/app/src/main/res/raw/roadmap.json
+++ b/app/src/main/res/raw/roadmap.json
@@ -7,39 +7,69 @@
         "lessonId": "lessonOneRmOne",
         "maxPoints": 10,
         "minPoints": 7,
-        "lessonName": "count 1-10",
+        "lessonName": "Lesson 1",
         "category": "numbers",
         "image": "elephant",
         "contents": [
           {
-            "lessonContentId": "lessonOneOne",
+            "lessonContentId": "lessonOneContentOne",
             "word": "one",
             "number": "1",
             "imgNum": "1"
           },
           {
-            "lessonContentId": "lessonOneTwo",
+            "lessonContentId": "lessonOneContentTwo",
             "word": "two",
             "number": "2",
             "imgNum": "2"
           },
           {
-            "lessonContentId": "lessonOneThree",
+            "lessonContentId": "lessonOneContentThree",
             "word": "three",
             "number": "3",
             "imgNum": "3"
           },
           {
-            "lessonContentId": "lessonOneFour",
+            "lessonContentId": "lessonOneContentFour",
             "word": "four",
             "number": "4",
-            "imgNum": "5"
+            "imgNum": "4"
           },
           {
-            "lessonContentId": "lessonOneFive",
+            "lessonContentId": "lessonOneContentFive",
             "word": "five",
             "number": "5",
             "imgNum": "5"
+          },
+          {
+            "lessonContentId": "lessonOneContentSix",
+            "word": "six",
+            "number": "6",
+            "imgNum": "6"
+          },
+          {
+            "lessonContentId": "lessonOneContentSeven",
+            "word": "seven",
+            "number": "7",
+            "imgNum": "7"
+          },
+          {
+            "lessonContentId": "lessonOneContentEight",
+            "word": "eight",
+            "number": "8",
+            "imgNum": "8"
+          },
+          {
+            "lessonContentId": "lessonOneContentNine",
+            "word": "nine",
+            "number": "9",
+            "imgNum": "9"
+          },
+          {
+            "lessonContentId": "lessonOneContentTen",
+            "word": "ten",
+            "number": "10",
+            "imgNum": "10"
           }
         ]
       },
@@ -47,17 +77,480 @@
         "lessonId": "lessonTwoRmOne",
         "maxPoints": 10,
         "minPoints": 7,
-        "lessonName": "adding 1-10",
+        "lessonName": "Lesson 2",
         "category": "addition",
-        "image": "elephant"
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonTwoContentOne",
+            "word": null,
+            "number": "1+1=2",
+            "imgNum": "1+1=2"
+          },
+          {
+            "lessonContentId": "lessonTwoContentTwo",
+            "word": null,
+            "number": "1+2=3",
+            "imgNum": "1+2=3"
+          },
+          {
+            "lessonContentId": "lessonTwoContentThree",
+            "word": null,
+            "number": "2+2=4",
+            "imgNum": "2+2=4"
+          },
+          {
+            "lessonContentId": "lessonTwoContentFour",
+            "word": null,
+            "number": "2+3=5",
+            "imgNum": "2+3=5"
+          },
+          {
+            "lessonContentId": "lessonTwoContentFive",
+            "word": null,
+            "number": "2+4=6",
+            "imgNum": "2+4=6"
+          },
+          {
+            "lessonContentId": "lessonTwoContentSix",
+            "word": null,
+            "number": "3+4=7",
+            "imgNum": "3+4=7"
+          },
+          {
+            "lessonContentId": "lessonTwoContentSeven",
+            "word": null,
+            "number": "2+6=8",
+            "imgNum": "2+6=8"
+          },
+          {
+            "lessonContentId": "lessonTwoContentEight",
+            "word": null,
+            "number": "4+5=9",
+            "imgNum": "4+5=9"
+          },
+          {
+            "lessonContentId": "lessonTwoContentNine",
+            "word": null,
+            "number": "5+5=10",
+            "imgNum": "5+5=10"
+          }
+        ]
       },
       {
         "lessonId": "lessonThreeRmOne",
         "maxPoints": 10,
         "minPoints": 7,
-        "lessonName": "unit 10s",
+        "lessonName": "Lesson 3",
         "category": "units",
-        "image": "elephant"
+        "image": "unit",
+        "contents": [
+          {
+            "lessonContentId": "lessonThreeContentOne",
+            "word":"une unité",
+            "number": null,
+            "imgNum": "oneUnit"
+          },
+          {
+            "lessonContentId": "lessonThreeContentTwo",
+            "word":"dix unités = une dizaine",
+            "number": null,
+            "imgNum": "tenUnits,oneTenUnit"
+          },
+          {
+            "lessonContentId": "lessonThreeContentThree",
+            "word":"une dizaine",
+            "number": null,
+            "imgNum": "oneTenUnit"
+          },
+          {
+            "lessonContentId": "lessonThreeContentFour",
+            "word": null,
+            "number": "5+5=",
+            "imgNum": "DUimg"
+          },
+          {
+            "lessonContentId": "lessonThreeContentFive",
+            "word": null,
+            "number": "4+6=",
+            "imgNum": "DUimg"
+          },
+          {
+            "lessonContentId": "lessonThreeContentSix",
+            "word": null,
+            "number": "7+3=",
+            "imgNum": "DUimg"
+          },
+          {
+            "lessonContentId": "lessonThreeContentSeven",
+            "word": null,
+            "number": "2+8=",
+            "imgNum": "DUimg"
+          },
+          {
+            "lessonContentId": "lessonThreeContentEight",
+            "word": null,
+            "number": "1+9=",
+            "imgNum": "DUimg"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonFourRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 4",
+        "category": "numbers",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonFourContentOne",
+            "word": "eleven",
+            "number": "1",
+            "imgNum": "1"
+          },
+          {
+            "lessonContentId": "lessonFourContentTwo",
+            "word": "twelve",
+            "number": "12",
+            "imgNum": "12"
+          },
+          {
+            "lessonContentId": "lessonFourContentThree",
+            "word": "thirteen",
+            "number": "13",
+            "imgNum": "13"
+          },
+          {
+            "lessonContentId": "lessonFourContentFour",
+            "word": "fourteen",
+            "number": "14",
+            "imgNum": "14"
+          },
+          {
+            "lessonContentId": "lessonFourContentFive",
+            "word": "fifteen",
+            "number": "15",
+            "imgNum": "15"
+          },
+          {
+            "lessonContentId": "lessonFourContentSix",
+            "word": "sixteen",
+            "number": "16",
+            "imgNum": "16"
+          },
+          {
+            "lessonContentId": "lessonFourContentSeven",
+            "word": "seventeen",
+            "number": "17",
+            "imgNum": "17"
+          },
+          {
+            "lessonContentId": "lessonFourContentEight",
+            "word": "eighteen",
+            "number": "18",
+            "imgNum": "18"
+          },
+          {
+            "lessonContentId": "lessonFourContentNine",
+            "word": "nineteen",
+            "number": "19",
+            "imgNum": "19"
+          },
+          {
+            "lessonContentId": "lessonFourContentTen",
+            "word": "twenty",
+            "number": "20",
+            "imgNum": "20"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonFiveRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 5",
+        "category": "subtraction",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonFiveContentOne",
+            "word": null,
+            "number": "2-1=1",
+            "imgNum": "2-1=1"
+          },
+          {
+            "lessonContentId": "lessonFiveContentTwo",
+            "word": null,
+            "number": "3-1=2",
+            "imgNum": "3-1=2"
+          },
+          {
+            "lessonContentId": "lessonFiveContentThree",
+            "word": null,
+            "number": "5-2=3",
+            "imgNum": "5-2=3"
+          },
+          {
+            "lessonContentId": "lessonFiveContentFour",
+            "word": null,
+            "number": "9-5=4",
+            "imgNum": "9-5=4"
+          },
+          {
+            "lessonContentId": "lessonFiveContentFive",
+            "word": null,
+            "number": "10-5=5",
+            "imgNum": "10-5=5"
+          },
+          {
+            "lessonContentId": "lessonFiveContentSix",
+            "word": null,
+            "number": "14-8=6",
+            "imgNum": "14-8=6"
+          },
+          {
+            "lessonContentId": "lessonFiveContentSeven",
+            "word": null,
+            "number": "16-9=7",
+            "imgNum": "16-9=7"
+          },
+          {
+            "lessonContentId": "lessonFiveContentEight",
+            "word": null,
+            "number": "18-10=8",
+            "imgNum": "18-10=8"
+          },
+          {
+            "lessonContentId": "lessonFiveContentNine",
+            "word": null,
+            "number": "20-11=9",
+            "imgNum": "20-11=9"
+          },
+          {
+            "lessonContentId": "lessonFiveContentTen",
+            "word": null,
+            "number": "20-10=10",
+            "imgNum": "20-10=10"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonSixRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 6",
+        "category": "multiplication",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonSixContentOne",
+            "word": null,
+            "number": "2x1=2",
+            "imgNum": "2in1"
+          },
+          {
+            "lessonContentId": "lessonSixContentTwo",
+            "word": null,
+            "number": "2x2=4",
+            "imgNum": "2in2"
+          },
+          {
+            "lessonContentId": "lessonSixContentThree",
+            "word": null,
+            "number": "2x3=6",
+            "imgNum": "2in3"
+          },
+          {
+            "lessonContentId": "lessonSixContentFour",
+            "word": null,
+            "number": "2x4=8",
+            "imgNum": "2in4"
+          },
+          {
+            "lessonContentId": "lessonSixContentFive",
+            "word": null,
+            "number": "2x5=10",
+            "imgNum": "2in5"
+          },
+          {
+            "lessonContentId": "lessonSixContentSix",
+            "word": null,
+            "number": "2x6=12",
+            "imgNum": "2in6"
+          },
+          {
+            "lessonContentId": "lessonSixContentSeven",
+            "word": null,
+            "number": "2x7=14",
+            "imgNum": "2in7"
+          },
+          {
+            "lessonContentId": "lessonSixContentEight",
+            "word": null,
+            "number": "2x8=16",
+            "imgNum": "2in8"
+          },
+          {
+            "lessonContentId": "lessonSixContentNine",
+            "word": null,
+            "number": "2x9=18",
+            "imgNum": "2in9"
+          },
+          {
+            "lessonContentId": "lessonSixContentTen",
+            "word": null,
+            "number": "2x10=20",
+            "imgNum": "2in10"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonSevenRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 7",
+        "category": "division",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonSevenContentOne",
+            "word": null,
+            "number": "2:2=1",
+            "imgNum": "2in1"
+          },
+          {
+            "lessonContentId": "lessonSevenContentTwo",
+            "word": null,
+            "number": "4:2=2",
+            "imgNum": "2in2"
+          },
+          {
+            "lessonContentId": "lessonSevenContentThree",
+            "word": null,
+            "number": "6:2=3",
+            "imgNum": "2in3"
+          },
+          {
+            "lessonContentId": "lessonSevenContentFour",
+            "word": null,
+            "number": "8:2=4",
+            "imgNum": "2in4"
+          },
+          {
+            "lessonContentId": "lessonSevenContentFive",
+            "word": null,
+            "number": "10:2=5",
+            "imgNum": "2in5"
+          },
+          {
+            "lessonContentId": "lessonSevenContentSix",
+            "word": null,
+            "number": "12:2=6",
+            "imgNum": "2in6"
+          },
+          {
+            "lessonContentId": "lessonSevenContentSeven",
+            "word": null,
+            "number": "14:2=7",
+            "imgNum": "2in7"
+          },
+          {
+            "lessonContentId": "lessonSevenContentEight",
+            "word": null,
+            "number": "16:2=8",
+            "imgNum": "2in8"
+          },
+          {
+            "lessonContentId": "lessonSevenContentNine",
+            "word": null,
+            "number": "18:2=9",
+            "imgNum": "2in9"
+          },
+          {
+            "lessonContentId": "lessonSevenContentTen",
+            "word": null,
+            "number": "20:2=10",
+            "imgNum": "2in10"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonEightRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 8",
+        "category": "multiplication",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonEightContentOne",
+            "word": null,
+            "number": "5x1=5",
+            "imgNum": "5in1"
+          },
+          {
+            "lessonContentId": "lessonEightContentTwo",
+            "word": null,
+            "number": "5x2=10",
+            "imgNum": "5in2"
+          },
+          {
+            "lessonContentId": "lessonEightContentThree",
+            "word": null,
+            "number": "5x3=15",
+            "imgNum": "5in3"
+          },
+          {
+            "lessonContentId": "lessonEightContentFour",
+            "word": null,
+            "number": "5x4=20",
+            "imgNum": "5in4"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonNineRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 9",
+        "category": "division",
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonNineContentOne",
+            "word": null,
+            "number": "5:5=1",
+            "imgNum": "5in1"
+          },
+          {
+            "lessonContentId": "lessonNineContentTwo",
+            "word": null,
+            "number": "10:5=2",
+            "imgNum": "5in2"
+          },
+          {
+            "lessonContentId": "lessonNineContentThree",
+            "word": null,
+            "number": "15:5=3",
+            "imgNum": "5in3"
+          },
+          {
+            "lessonContentId": "lessonNineContentFour",
+            "word": null,
+            "number": "20:5=4",
+            "imgNum": "5in4"
+          }
+        ]
+      },
+      {
+        "lessonId": "lessonTenRmOne",
+        "maxPoints": 10,
+        "minPoints": 7,
+        "lessonName": "Lesson 10",
+        "category": null,
+        "image": null,
+        "contents": null
       }
     ],
     "quizzes": null,

--- a/app/src/main/res/raw/roadmap.json
+++ b/app/src/main/res/raw/roadmap.json
@@ -9,7 +9,39 @@
         "minPoints": 7,
         "lessonName": "count 1-10",
         "category": "numbers",
-        "image": "elephant"
+        "image": "elephant",
+        "contents": [
+          {
+            "lessonContentId": "lessonOneOne",
+            "word": "one",
+            "number": "1",
+            "imgNum": "1"
+          },
+          {
+            "lessonContentId": "lessonOneTwo",
+            "word": "two",
+            "number": "2",
+            "imgNum": "2"
+          },
+          {
+            "lessonContentId": "lessonOneThree",
+            "word": "three",
+            "number": "3",
+            "imgNum": "3"
+          },
+          {
+            "lessonContentId": "lessonOneFour",
+            "word": "four",
+            "number": "4",
+            "imgNum": "5"
+          },
+          {
+            "lessonContentId": "lessonOneFive",
+            "word": "five",
+            "number": "5",
+            "imgNum": "5"
+          }
+        ]
       },
       {
         "lessonId": "lessonTwoRmOne",

--- a/app/src/main/res/raw/roadmap.json
+++ b/app/src/main/res/raw/roadmap.json
@@ -14,70 +14,142 @@
           {
             "lessonContentId": "lessonOneContentOne",
             "word": "one",
-            "firstNumber": "",
-            "firstOperator": "",
-            "secondNumber": "",
-            "secondOperator": "",
-            "thirdNumber": "",
-            "imgOne": "",
-            "imgTwo": "",
-            "imgThree": "",
-            "imgFour": "",
-            "imgFive": ""
+            "firstNumber": "1",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentTwo",
             "word": "two",
-            "number": "2",
-            "imgNum": "2"
+            "firstNumber": "2",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentThree",
             "word": "three",
-            "number": "3",
-            "imgNum": "3"
+            "firstNumber": "3",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentFour",
             "word": "four",
-            "number": "4",
-            "imgNum": "4"
+            "firstNumber": "4",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentFive",
             "word": "five",
-            "number": "5",
-            "imgNum": "5"
+            "firstNumber": "5",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentSix",
             "word": "six",
-            "number": "6",
-            "imgNum": "6"
+            "firstNumber": "6",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentSeven",
             "word": "seven",
-            "number": "7",
-            "imgNum": "7"
+            "firstNumber": "7",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentEight",
             "word": "eight",
-            "number": "8",
-            "imgNum": "8"
+            "firstNumber": "8",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentNine",
             "word": "nine",
-            "number": "9",
-            "imgNum": "9"
+            "firstNumber": "9",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonOneContentTen",
             "word": "ten",
-            "number": "10",
-            "imgNum": "10"
+            "firstNumber": "10",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -92,56 +164,128 @@
           {
             "lessonContentId": "lessonTwoContentOne",
             "word": null,
-            "number": "1+1=2",
-            "imgNum": "1+1=2"
+            "firstNumber": "1",
+            "firstOperator": "+",
+            "secondNumber": "1",
+            "secondOperator": "=",
+            "thirdNumber": "2",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentTwo",
             "word": null,
-            "number": "1+2=3",
-            "imgNum": "1+2=3"
+            "firstNumber": "1",
+            "firstOperator": "+",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "3",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentThree",
             "word": null,
-            "number": "2+2=4",
-            "imgNum": "2+2=4"
+            "firstNumber": "2",
+            "firstOperator": "+",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "4",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentFour",
             "word": null,
-            "number": "2+3=5",
-            "imgNum": "2+3=5"
+            "firstNumber": "2",
+            "firstOperator": "+",
+            "secondNumber": "3",
+            "secondOperator": "=",
+            "thirdNumber": "5",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentFive",
             "word": null,
-            "number": "2+4=6",
-            "imgNum": "2+4=6"
+            "firstNumber": "2",
+            "firstOperator": "+",
+            "secondNumber": "4",
+            "secondOperator": "=",
+            "thirdNumber": "6",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentSix",
             "word": null,
-            "number": "3+4=7",
-            "imgNum": "3+4=7"
+            "firstNumber": "3",
+            "firstOperator": "+",
+            "secondNumber": "4",
+            "secondOperator": "=",
+            "thirdNumber": "7",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentSeven",
             "word": null,
-            "number": "2+6=8",
-            "imgNum": "2+6=8"
+            "firstNumber": "2",
+            "firstOperator": "+",
+            "secondNumber": "6",
+            "secondOperator": "=",
+            "thirdNumber": "8",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentEight",
             "word": null,
-            "number": "4+5=9",
-            "imgNum": "4+5=9"
+            "firstNumber": "4",
+            "firstOperator": "+",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "9",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonTwoContentNine",
             "word": null,
-            "number": "5+5=10",
-            "imgNum": "5+5=10"
+            "firstNumber": "5",
+            "firstOperator": "+",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "10",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -156,50 +300,114 @@
           {
             "lessonContentId": "lessonThreeContentOne",
             "word":"une unité",
-            "number": null,
-            "imgNum": "oneUnit"
+            "firstNumber": null,
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": "oneUnit",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentTwo",
-            "word":"dix unités = une dizaine",
-            "number": null,
-            "imgNum": "tenUnits,oneTenUnit"
+            "word": null,
+            "firstNumber": "dix unités",
+            "firstOperator": "=",
+            "secondNumber": "une dizaine",
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": "tenOneUnits",
+            "imgTwo": "tenUnit",
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentThree",
             "word":"une dizaine",
-            "number": null,
-            "imgNum": "oneTenUnit"
+            "firstNumber": null,
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": "tenUnit",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentFour",
             "word": null,
-            "number": "5+5=",
-            "imgNum": "DUimg"
+            "firstNumber": "5",
+            "firstOperator": "+",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": null,
+            "imgOne": "DUimg",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentFive",
             "word": null,
-            "number": "4+6=",
-            "imgNum": "DUimg"
+            "firstNumber": "4",
+            "firstOperator": "+",
+            "secondNumber": "6",
+            "secondOperator": "=",
+            "thirdNumber": null,
+            "imgOne": "DUimg",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentSix",
             "word": null,
-            "number": "7+3=",
-            "imgNum": "DUimg"
+            "firstNumber": "7",
+            "firstOperator": "+",
+            "secondNumber": "3",
+            "secondOperator": "=",
+            "thirdNumber": null,
+            "imgOne": "DUimg",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentSeven",
             "word": null,
-            "number": "2+8=",
-            "imgNum": "DUimg"
+            "firstNumber": "2",
+            "firstOperator": "+",
+            "secondNumber": "8",
+            "secondOperator": "=",
+            "thirdNumber": null,
+            "imgOne": "DUimg",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonThreeContentEight",
             "word": null,
-            "number": "1+9=",
-            "imgNum": "DUimg"
+            "firstNumber": "1",
+            "firstOperator": "+",
+            "secondNumber": "9",
+            "secondOperator": "=",
+            "thirdNumber": null,
+            "imgOne": "DUimg",
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -214,62 +422,142 @@
           {
             "lessonContentId": "lessonFourContentOne",
             "word": "eleven",
-            "number": "1",
-            "imgNum": "1"
+            "firstNumber": "11",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentTwo",
             "word": "twelve",
-            "number": "12",
-            "imgNum": "12"
+            "firstNumber": "12",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentThree",
             "word": "thirteen",
-            "number": "13",
-            "imgNum": "13"
+            "firstNumber": "13",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentFour",
             "word": "fourteen",
-            "number": "14",
-            "imgNum": "14"
+            "firstNumber": "14",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentFive",
             "word": "fifteen",
-            "number": "15",
-            "imgNum": "15"
+            "firstNumber": "15",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentSix",
             "word": "sixteen",
-            "number": "16",
-            "imgNum": "16"
+            "firstNumber": "16",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentSeven",
             "word": "seventeen",
-            "number": "17",
-            "imgNum": "17"
+            "firstNumber": "17",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentEight",
             "word": "eighteen",
-            "number": "18",
-            "imgNum": "18"
+            "firstNumber": "18",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentNine",
             "word": "nineteen",
-            "number": "19",
-            "imgNum": "19"
+            "firstNumber": "19",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFourContentTen",
             "word": "twenty",
-            "number": "20",
-            "imgNum": "20"
+            "firstNumber": "20",
+            "firstOperator": null,
+            "secondNumber": null,
+            "secondOperator": null,
+            "thirdNumber": null,
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -284,62 +572,142 @@
           {
             "lessonContentId": "lessonFiveContentOne",
             "word": null,
-            "number": "2-1=1",
-            "imgNum": "2-1=1"
+            "firstNumber": "2",
+            "firstOperator": "-",
+            "secondNumber": "1",
+            "secondOperator": "=",
+            "thirdNumber": "1",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentTwo",
             "word": null,
-            "number": "3-1=2",
-            "imgNum": "3-1=2"
+            "firstNumber": "3",
+            "firstOperator": "-",
+            "secondNumber": "1",
+            "secondOperator": "=",
+            "thirdNumber": "2",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentThree",
             "word": null,
-            "number": "5-2=3",
-            "imgNum": "5-2=3"
+            "firstNumber": "5",
+            "firstOperator": "-",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "3",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentFour",
             "word": null,
-            "number": "9-5=4",
-            "imgNum": "9-5=4"
+            "firstNumber": "9",
+            "firstOperator": "-",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "4",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentFive",
             "word": null,
-            "number": "10-5=5",
-            "imgNum": "10-5=5"
+            "firstNumber": "10",
+            "firstOperator": "-",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "5",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentSix",
             "word": null,
-            "number": "14-8=6",
-            "imgNum": "14-8=6"
+            "firstNumber": "14",
+            "firstOperator": "-",
+            "secondNumber": "8",
+            "secondOperator": "=",
+            "thirdNumber": "6",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentSeven",
             "word": null,
-            "number": "16-9=7",
-            "imgNum": "16-9=7"
+            "firstNumber": "16",
+            "firstOperator": "-",
+            "secondNumber": "9",
+            "secondOperator": "=",
+            "thirdNumber": "7",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentEight",
             "word": null,
-            "number": "18-10=8",
-            "imgNum": "18-10=8"
+            "firstNumber": "18",
+            "firstOperator": "-",
+            "secondNumber": "10",
+            "secondOperator": "=",
+            "thirdNumber": "8",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentNine",
             "word": null,
-            "number": "20-11=9",
-            "imgNum": "20-11=9"
+            "firstNumber": "20",
+            "firstOperator": "-",
+            "secondNumber": "11",
+            "secondOperator": "=",
+            "thirdNumber": "9",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonFiveContentTen",
             "word": null,
-            "number": "20-10=10",
-            "imgNum": "20-10=10"
+            "firstNumber": "20",
+            "firstOperator": "-",
+            "secondNumber": "10",
+            "secondOperator": "=",
+            "thirdNumber": "10",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -354,62 +722,142 @@
           {
             "lessonContentId": "lessonSixContentOne",
             "word": null,
-            "number": "2x1=2",
-            "imgNum": "2in1"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "1",
+            "secondOperator": "=",
+            "thirdNumber": "2",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentTwo",
             "word": null,
-            "number": "2x2=4",
-            "imgNum": "2in2"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "4",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentThree",
             "word": null,
-            "number": "2x3=6",
-            "imgNum": "2in3"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "3",
+            "secondOperator": "=",
+            "thirdNumber": "6",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentFour",
             "word": null,
-            "number": "2x4=8",
-            "imgNum": "2in4"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "4",
+            "secondOperator": "=",
+            "thirdNumber": "8",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentFive",
             "word": null,
-            "number": "2x5=10",
-            "imgNum": "2in5"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "10",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentSix",
             "word": null,
-            "number": "2x6=12",
-            "imgNum": "2in6"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "6",
+            "secondOperator": "=",
+            "thirdNumber": "12",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentSeven",
             "word": null,
-            "number": "2x7=14",
-            "imgNum": "2in7"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "7",
+            "secondOperator": "=",
+            "thirdNumber": "14",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentEight",
             "word": null,
-            "number": "2x8=16",
-            "imgNum": "2in8"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "8",
+            "secondOperator": "=",
+            "thirdNumber": "16",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentNine",
             "word": null,
-            "number": "2x9=18",
-            "imgNum": "2in9"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "9",
+            "secondOperator": "=",
+            "thirdNumber": "18",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSixContentTen",
             "word": null,
-            "number": "2x10=20",
-            "imgNum": "2in10"
+            "firstNumber": "2",
+            "firstOperator": "x",
+            "secondNumber": "10",
+            "secondOperator": "=",
+            "thirdNumber": "20",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -424,62 +872,142 @@
           {
             "lessonContentId": "lessonSevenContentOne",
             "word": null,
-            "number": "2:2=1",
-            "imgNum": "2in1"
+            "firstNumber": "2",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "1",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentTwo",
             "word": null,
-            "number": "4:2=2",
-            "imgNum": "2in2"
+            "firstNumber": "4",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "2",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentThree",
             "word": null,
-            "number": "6:2=3",
-            "imgNum": "2in3"
+            "firstNumber": "6",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "3",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentFour",
             "word": null,
-            "number": "8:2=4",
-            "imgNum": "2in4"
+            "firstNumber": "8",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "4",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentFive",
             "word": null,
-            "number": "10:2=5",
-            "imgNum": "2in5"
+            "firstNumber": "10",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "5",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentSix",
             "word": null,
-            "number": "12:2=6",
-            "imgNum": "2in6"
+            "firstNumber": "12",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "6",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentSeven",
             "word": null,
-            "number": "14:2=7",
-            "imgNum": "2in7"
+            "firstNumber": "14",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "7",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentEight",
             "word": null,
-            "number": "16:2=8",
-            "imgNum": "2in8"
+            "firstNumber": "16",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "8",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentNine",
             "word": null,
-            "number": "18:2=9",
-            "imgNum": "2in9"
+            "firstNumber": "18",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "9",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonSevenContentTen",
             "word": null,
-            "number": "20:2=10",
-            "imgNum": "2in10"
+            "firstNumber": "20",
+            "firstOperator": ":",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "10",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -494,26 +1022,58 @@
           {
             "lessonContentId": "lessonEightContentOne",
             "word": null,
-            "number": "5x1=5",
-            "imgNum": "5in1"
+            "firstNumber": "5",
+            "firstOperator": "x",
+            "secondNumber": "1",
+            "secondOperator": "=",
+            "thirdNumber": "5",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonEightContentTwo",
             "word": null,
-            "number": "5x2=10",
-            "imgNum": "5in2"
+            "firstNumber": "5",
+            "firstOperator": "x",
+            "secondNumber": "2",
+            "secondOperator": "=",
+            "thirdNumber": "10",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonEightContentThree",
             "word": null,
-            "number": "5x3=15",
-            "imgNum": "5in3"
+            "firstNumber": "5",
+            "firstOperator": "x",
+            "secondNumber": "3",
+            "secondOperator": "=",
+            "thirdNumber": "15",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonEightContentFour",
             "word": null,
-            "number": "5x4=20",
-            "imgNum": "5in4"
+            "firstNumber": "5",
+            "firstOperator": "x",
+            "secondNumber": "4",
+            "secondOperator": "=",
+            "thirdNumber": "20",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },
@@ -528,26 +1088,58 @@
           {
             "lessonContentId": "lessonNineContentOne",
             "word": null,
-            "number": "5:5=1",
-            "imgNum": "5in1"
+            "firstNumber": "5",
+            "firstOperator": ":",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "1",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonNineContentTwo",
             "word": null,
-            "number": "10:5=2",
-            "imgNum": "5in2"
+            "firstNumber": "10",
+            "firstOperator": ":",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "2",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonNineContentThree",
             "word": null,
-            "number": "15:5=3",
-            "imgNum": "5in3"
+            "firstNumber": "15",
+            "firstOperator": ":",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "3",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           },
           {
             "lessonContentId": "lessonNineContentFour",
             "word": null,
-            "number": "20:5=4",
-            "imgNum": "5in4"
+            "firstNumber": "20",
+            "firstOperator": ":",
+            "secondNumber": "5",
+            "secondOperator": "=",
+            "thirdNumber": "4",
+            "imgOne": null,
+            "imgTwo": null,
+            "imgThree": null,
+            "imgFour": null,
+            "imgFive": null
           }
         ]
       },


### PR DESCRIPTION
Created a new schema called LessonContent which contains word, number, and imgNum strings. Each lesson contains a RealmList of LessonContents so that we can map the content for each lesson to its appropriate fragment. 

Test this out by running locally and clearing Realm database. When you create a child, you should see the 75 Lesson Content s and 10 Lesson Schemas for Roadmap Level 1.

Completes issue: #49 