### PR TITLE
added cat count fields to child

### DIFF
--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/child/ChildSchema.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/child/ChildSchema.java
@@ -15,6 +15,18 @@ public class ChildSchema extends RealmObject {
     ChildRoadMap roadMapTwo;
     ChildRoadMap roadMapThree;
     ChildRoadMap roadMapFour;
+    private Integer catCountNumbers;
+    private Integer catCountUnits;
+    private Integer catCountAddition;
+    private Integer catCountSubtraction;
+    private Integer catCountMultiplication;
+    private Integer catCountDivision;
+    private Integer catCountLength;
+    private Integer catCountWeightVolume;
+    private Integer catCountMoney;
+    private Integer catCountTime;
+    private Integer catCountShapes;
+    private Integer catCountAngles;
 
     public String getChildId() {
         return childId;
@@ -86,5 +98,101 @@ public class ChildSchema extends RealmObject {
 
     public void setRoadMapFour(ChildRoadMap roadMapFour) {
         this.roadMapFour = roadMapFour;
+    }
+
+    public Integer getCatCountNumbers() {
+        return catCountNumbers;
+    }
+
+    public void setCatCountNumbers(Integer catCountNumbers) {
+        this.catCountNumbers = catCountNumbers;
+    }
+
+    public Integer getCatCountUnits() {
+        return catCountUnits;
+    }
+
+    public void setCatCountUnits(Integer catCountUnits) {
+        this.catCountUnits = catCountUnits;
+    }
+
+    public Integer getCatCountAddition() {
+        return catCountAddition;
+    }
+
+    public void setCatCountAddition(Integer catCountAddition) {
+        this.catCountAddition = catCountAddition;
+    }
+
+    public Integer getCatCountSubtraction() {
+        return catCountSubtraction;
+    }
+
+    public void setCatCountSubtraction(Integer catCountSubtraction) {
+        this.catCountSubtraction = catCountSubtraction;
+    }
+
+    public Integer getCatCountMultiplication() {
+        return catCountMultiplication;
+    }
+
+    public void setCatCountMultiplication(Integer catCountMultiplication) {
+        this.catCountMultiplication = catCountMultiplication;
+    }
+
+    public Integer getCatCountDivision() {
+        return catCountDivision;
+    }
+
+    public void setCatCountDivision(Integer catCountDivision) {
+        this.catCountDivision = catCountDivision;
+    }
+
+    public Integer getCatCountLength() {
+        return catCountLength;
+    }
+
+    public void setCatCountLength(Integer catCountLength) {
+        this.catCountLength = catCountLength;
+    }
+
+    public Integer getCatCountWeightVolume() {
+        return catCountWeightVolume;
+    }
+
+    public void setCatCountWeightVolume(Integer catCountWeightVolume) {
+        this.catCountWeightVolume = catCountWeightVolume;
+    }
+
+    public Integer getCatCountMoney() {
+        return catCountMoney;
+    }
+
+    public void setCatCountMoney(Integer catCountMoney) {
+        this.catCountMoney = catCountMoney;
+    }
+
+    public Integer getCatCountTime() {
+        return catCountTime;
+    }
+
+    public void setCatCountTime(Integer catCountTime) {
+        this.catCountTime = catCountTime;
+    }
+
+    public Integer getCatCountShapes() {
+        return catCountShapes;
+    }
+
+    public void setCatCountShapes(Integer catCountShapes) {
+        this.catCountShapes = catCountShapes;
+    }
+
+    public Integer getCatCountAngles() {
+        return catCountAngles;
+    }
+
+    public void setCatCountAngles(Integer catCountAngles) {
+        this.catCountAngles = catCountAngles;
     }
 }

--- a/app/src/main/java/com/GrowthPlus/dataAccessLayer/child/ChildSchemaService.java
+++ b/app/src/main/java/com/GrowthPlus/dataAccessLayer/child/ChildSchemaService.java
@@ -64,7 +64,18 @@ public class ChildSchemaService {
             newChild.setRoadMapTwo(childRoadMapTwo);
             newChild.setRoadMapThree(childRoadMapThree);
             newChild.setRoadMapFour(childRoadMapFour);
-
+            newChild.setCatCountNumbers(0);
+            newChild.setCatCountUnits(0);
+            newChild.setCatCountAddition(0);
+            newChild.setCatCountSubtraction(0);
+            newChild.setCatCountMultiplication(0);
+            newChild.setCatCountDivision(0);
+            newChild.setCatCountLength(0);
+            newChild.setCatCountWeightVolume(0);
+            newChild.setCatCountMoney(0);
+            newChild.setCatCountTime(0);
+            newChild.setCatCountShapes(0);
+            newChild.setCatCountAngles(0);
         }, () -> { //Lambda expression
             /* success actions */
             Log.i("Success", "New child added to realm!");


### PR DESCRIPTION
This PR add category counters to child schema. These counters will increase as the child completes lessons. 

To test:
Uninstall and rebuild the app. 
Create a parent account and child. 
Inspect the realm file, make sure the category count counters in child schema are present and initialized to 0. 