### PR TITLE
Mack/add timer to games

### DIFF
--- a/app/src/main/java/com/GrowthPlus/Game2.java
+++ b/app/src/main/java/com/GrowthPlus/Game2.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.os.Handler;
 import android.util.Log;
 import android.view.View;
@@ -16,6 +17,7 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.GrowthPlus.customViews.Banana;
+import com.GrowthPlus.customViews.CustomTimerComponent;
 import com.GrowthPlus.customViews.TopBar;
 import com.GrowthPlus.dataAccessLayer.ChildRoadMap.ChildRoadMap;
 import com.GrowthPlus.dataAccessLayer.RoadMapLesson.RoadMapLesson;
@@ -49,6 +51,8 @@ public class Game2 extends AppCompatActivity {
     ObjectAnimator animator1, animator2, animator3;
     private MediaPlayer correct, incorrect, background;
     ConstraintLayout topBarBackground;
+    private CountDownTimer countDownTimer;
+    private CustomTimerComponent customTimerComponent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -60,9 +64,12 @@ public class Game2 extends AppCompatActivity {
         introBackBtn.setOnClickListener(view -> {
             setCompletedState(gameScore);
             background.stop();
+            countDownTimer.cancel(); //since the user is exiting the game we need to stop the timer
+
         });
         setTopBar();
         setContent();
+        setTimer();
     }
 
     private void init(){
@@ -245,6 +252,7 @@ public class Game2 extends AppCompatActivity {
                 b3.setVisibility(View.VISIBLE);
                 correctB.setVisibility(View.INVISIBLE);
                 setContent();
+                setTimer();
             }
         }, 2500);
     }
@@ -340,5 +348,23 @@ public class Game2 extends AppCompatActivity {
     protected void onDestroy() {
         if (!realm.isClosed()) realm.close();
         super.onDestroy();
+    }
+
+    //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
+    private void setTimer() {
+        customTimerComponent = findViewById(R.id.countdownTimer);
+        countDownTimer = new CountDownTimer(5000, 1000) {
+
+            public void onTick(long millisUntilFinished) {
+                customTimerComponent.setTimerText(""+millisUntilFinished / 1000);
+            }
+            public void onFinish() {
+                countDownTimer.cancel();
+                playIncorrect();
+                wrongAnimation(b1, b2, b3);
+                deactivate();
+                showNext();
+            }
+        }.start();
     }
 }

--- a/app/src/main/java/com/GrowthPlus/Game2.java
+++ b/app/src/main/java/com/GrowthPlus/Game2.java
@@ -359,7 +359,7 @@ public class Game2 extends AppCompatActivity {
     //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
     private void setTimer() {
         customTimerComponent = findViewById(R.id.countdownTimer);
-        countDownTimer = new CountDownTimer(5000, 1000) {
+        countDownTimer = new CountDownTimer(21000, 1000) {
 
             public void onTick(long millisUntilFinished) {
                 customTimerComponent.setTimerText(""+millisUntilFinished / 1000);

--- a/app/src/main/java/com/GrowthPlus/Game2.java
+++ b/app/src/main/java/com/GrowthPlus/Game2.java
@@ -138,6 +138,8 @@ public class Game2 extends AppCompatActivity {
         bounceAnimation(b1, b2, b3);
 
         b1.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(b1.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 playCorrect();
                 showCorrect();
@@ -160,6 +162,8 @@ public class Game2 extends AppCompatActivity {
         });
 
         b2.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(b2.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 numberCorrect++;
                 playCorrect();
@@ -182,6 +186,8 @@ public class Game2 extends AppCompatActivity {
         });
 
         b3.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(b3.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 numberCorrect++;
                 playCorrect();

--- a/app/src/main/java/com/GrowthPlus/Game3.java
+++ b/app/src/main/java/com/GrowthPlus/Game3.java
@@ -352,7 +352,7 @@ public class Game3 extends AppCompatActivity {
     //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
     private void setTimer() {
         customTimerComponent = findViewById(R.id.countdownTimer);
-        countDownTimer = new CountDownTimer(5000, 1000) {
+        countDownTimer = new CountDownTimer(21000, 1000) {
 
             public void onTick(long millisUntilFinished) {
                 customTimerComponent.setTimerText(""+millisUntilFinished / 1000);

--- a/app/src/main/java/com/GrowthPlus/Game3.java
+++ b/app/src/main/java/com/GrowthPlus/Game3.java
@@ -8,11 +8,13 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.os.Handler;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.GrowthPlus.customViews.CustomTimerComponent;
 import com.GrowthPlus.customViews.Soccer;
 import com.GrowthPlus.customViews.TopBar;
 import com.GrowthPlus.dataAccessLayer.ChildRoadMap.ChildRoadMap;
@@ -47,6 +49,8 @@ public class Game3 extends AppCompatActivity {
     ObjectAnimator move1a, move1b, move2a, move2b, move3a, move3b, move4a, move4b, move5a, move5b, move6a, move6b;
     private MediaPlayer correct, incorrect, background;
     ConstraintLayout topBarBackground;
+    private CountDownTimer countDownTimer;
+    private CustomTimerComponent customTimerComponent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,9 +62,11 @@ public class Game3 extends AppCompatActivity {
         introBackBtn.setOnClickListener(view -> {
             setCompletedState(gameScore);
             background.stop();
+            countDownTimer.cancel(); //since the user is exiting the game we need to stop the timer
         });
         setTopBar();
         setContent();
+        setTimer();
     }
 
 
@@ -152,6 +158,8 @@ public class Game3 extends AppCompatActivity {
         ball3.setNumber(contents.get(forty.get(counter)).getOptionThree());
 
         ball1.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             ball2.setVisibility(View.INVISIBLE);
             ball3.setVisibility(View.INVISIBLE);
             deactivate();
@@ -179,6 +187,8 @@ public class Game3 extends AppCompatActivity {
         });
 
         ball2.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             ball1.setVisibility(View.INVISIBLE);
             ball3.setVisibility(View.INVISIBLE);
             deactivate();
@@ -206,6 +216,8 @@ public class Game3 extends AppCompatActivity {
         });
 
         ball3.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             ball1.setVisibility(View.INVISIBLE);
             ball2.setVisibility(View.INVISIBLE);
             deactivate();
@@ -277,6 +289,7 @@ public class Game3 extends AppCompatActivity {
                 ball2.setVisibility(View.VISIBLE);
                 ball3.setVisibility(View.VISIBLE);
                 setContent();
+                setTimer();
             }
         }, 3000);
     }
@@ -334,5 +347,28 @@ public class Game3 extends AppCompatActivity {
     protected void onDestroy() {
         if (!realm.isClosed()) realm.close();
         super.onDestroy();
+    }
+
+    //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
+    private void setTimer() {
+        customTimerComponent = findViewById(R.id.countdownTimer);
+        countDownTimer = new CountDownTimer(5000, 1000) {
+
+            public void onTick(long millisUntilFinished) {
+                customTimerComponent.setTimerText(""+millisUntilFinished / 1000);
+            }
+            public void onFinish() {
+                countDownTimer.cancel();
+                playIncorrect();
+                move4a.start();
+                move4b.start();
+                move5a.start();
+                move5b.start();
+                move6a.start();
+                move6b.start();
+                deactivate();
+                showNext();
+            }
+        }.start();
     }
 }

--- a/app/src/main/java/com/GrowthPlus/Game4.java
+++ b/app/src/main/java/com/GrowthPlus/Game4.java
@@ -332,7 +332,7 @@ public class Game4 extends AppCompatActivity {
     //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
     private void setTimer() {
         customTimerComponent = findViewById(R.id.countdownTimer);
-        countDownTimer = new CountDownTimer(5000, 1000) {
+        countDownTimer = new CountDownTimer(21000, 1000) {
 
             public void onTick(long millisUntilFinished) {
                 customTimerComponent.setTimerText(""+millisUntilFinished / 1000);

--- a/app/src/main/java/com/GrowthPlus/Game4.java
+++ b/app/src/main/java/com/GrowthPlus/Game4.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.media.MediaPlayer;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.os.CountDownTimer;
 import android.os.Handler;
 import android.view.View;
 import android.view.animation.Interpolator;
@@ -15,6 +16,7 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.GrowthPlus.customViews.Coconut;
+import com.GrowthPlus.customViews.CustomTimerComponent;
 import com.GrowthPlus.customViews.TopBar;
 import com.GrowthPlus.dataAccessLayer.ScenarioGame.ScenarioGameContent;
 import com.GrowthPlus.dataAccessLayer.ScenarioGame.ScenarioGameSchema;
@@ -45,6 +47,8 @@ public class Game4 extends AppCompatActivity {
     ObjectAnimator animator1, animator2, animator3, animator4;
     private MediaPlayer correct, incorrect, background;
     ConstraintLayout topBarBackground;
+    private CountDownTimer countDownTimer;
+    private CustomTimerComponent customTimerComponent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -56,9 +60,11 @@ public class Game4 extends AppCompatActivity {
         introBackBtn.setOnClickListener(view -> {
             setCompletedState(gameScore);
             background.stop();
+            countDownTimer.cancel(); //since the user is exiting the game we need to stop the timer
         });
         setTopBar();
         setContent();
+        setTimer();
     }
 
     private void init(){
@@ -123,6 +129,8 @@ public class Game4 extends AppCompatActivity {
         keepBouncing(c1, c2, c3);
 
         c1.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(c1.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 fallAnimation(c1);
                 playCorrect();
@@ -145,6 +153,8 @@ public class Game4 extends AppCompatActivity {
         });
 
         c2.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(c2.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 numberCorrect++;
                 fallAnimation(c2);
@@ -167,6 +177,8 @@ public class Game4 extends AppCompatActivity {
         });
 
         c3.setOnClickListener(v -> {
+            countDownTimer.cancel(); //the user selected an answer so we can stop the timer
+
             if(c3.getNumber().equals(contents.get(forty.get(counter)).getAnswer())) { // CORRECT
                 numberCorrect++;
                 fallAnimation(c3);
@@ -229,6 +241,7 @@ public class Game4 extends AppCompatActivity {
                 c3.animate().translationY(0);
                 c3.animate().setDuration(500);
                 setContent();
+                setTimer();
             }
         }, 2500);
     }
@@ -314,5 +327,23 @@ public class Game4 extends AppCompatActivity {
     protected void onDestroy() {
         if (!realm.isClosed()) realm.close();
         super.onDestroy();
+    }
+
+    //sets a timer that counts down from 30 and moves on if the user doesn't choose an answer in time
+    private void setTimer() {
+        customTimerComponent = findViewById(R.id.countdownTimer);
+        countDownTimer = new CountDownTimer(5000, 1000) {
+
+            public void onTick(long millisUntilFinished) {
+                customTimerComponent.setTimerText(""+millisUntilFinished / 1000);
+            }
+            public void onFinish() {
+                countDownTimer.cancel();
+                playIncorrect();
+                wrongAnimation(c1, c2, c3);
+                deactivate();
+                showCorrect();
+            }
+        }.start();
     }
 }

--- a/app/src/main/res/layouts/levels/layout/activity_game2.xml
+++ b/app/src/main/res/layouts/levels/layout/activity_game2.xml
@@ -88,4 +88,18 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/guide_middle" />
+
+    <com.GrowthPlus.customViews.CustomTimerComponent
+        android:id="@+id/countdownTimer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:paddingEnd="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.988"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.108" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layouts/levels/layout/activity_game3.xml
+++ b/app/src/main/res/layouts/levels/layout/activity_game3.xml
@@ -68,4 +68,18 @@
         android:layout_marginBottom="60dp"
         app:layout_constraintBottom_toTopOf="@+id/guide_bottom"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.GrowthPlus.customViews.CustomTimerComponent
+        android:id="@+id/countdownTimer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:paddingEnd="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.988"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.108" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layouts/levels/layout/activity_game4.xml
+++ b/app/src/main/res/layouts/levels/layout/activity_game4.xml
@@ -60,4 +60,18 @@
         android:scaleY="1.05"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/game4TopBar" />
+
+    <com.GrowthPlus.customViews.CustomTimerComponent
+        android:id="@+id/countdownTimer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="10dp"
+        android:paddingEnd="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.988"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.108" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR closes issue #142. Scenario games 2-4 now have timers that count down from 20. Not a lot to say, but I guess I'll point out some things to be extra clear:

- If the time runs out we move to the next question automatically.
- If you choose an answer, the timer stops counting down.
- If you click the back button to get out of the game, the timer stops counting down.
- As you'd expect, if you get through all the questions of the game, the timer goes away.

To test just go through games 2-4 and also do some weird stuff like exiting the game in the middle, letting the timer run out for some questions (especially the last question), etc.

P.S. After my other PR is merged into main, I need to update this branch with main before we merge this one